### PR TITLE
Fix `returnUrl`

### DIFF
--- a/BlazorIntAuto/Components/Login.razor
+++ b/BlazorIntAuto/Components/Login.razor
@@ -3,6 +3,6 @@
         <a href="Account/Logout">Log out</a>
     </Authorized>
     <NotAuthorized>
-        <a href="Account/Login?redirectUri=/">Log in</a>
+        <a href="Account/Login">Log in</a>
     </NotAuthorized>
 </AuthorizeView>

--- a/BlazorIntAuto/Program.cs
+++ b/BlazorIntAuto/Program.cs
@@ -40,10 +40,10 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseAntiforgery();
 
-app.MapGet("/Account/Login", async (HttpContext httpContext, string redirectUri = "/") =>
+app.MapGet("/Account/Login", async (HttpContext httpContext, string returnUrl = "/") =>
 {
   var authenticationProperties = new LoginAuthenticationPropertiesBuilder()
-          .WithRedirectUri(redirectUri)
+          .WithRedirectUri(returnUrl)
           .Build();
 
   await httpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);

--- a/BlazorIntAuto/Program.cs
+++ b/BlazorIntAuto/Program.cs
@@ -49,10 +49,10 @@ app.MapGet("/Account/Login", async (HttpContext httpContext, string returnUrl = 
   await httpContext.ChallengeAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);
 });
 
-app.MapGet("/Account/Logout", async (HttpContext httpContext, string redirectUri = "/") =>
+app.MapGet("/Account/Logout", async (HttpContext httpContext) =>
 {
   var authenticationProperties = new LogoutAuthenticationPropertiesBuilder()
-          .WithRedirectUri(redirectUri)
+          .WithRedirectUri("/")
           .Build();
 
   await httpContext.SignOutAsync(Auth0Constants.AuthenticationScheme, authenticationProperties);


### PR DESCRIPTION
This PR fixes the reference to the builtin `returnUrl` parameter to go back to the calling page after login