### PR TITLE
Upgrade to .NET 9.0 and update package versions

### DIFF
--- a/BlazorIntAuto.Client/BlazorIntAuto.Client.csproj
+++ b/BlazorIntAuto.Client/BlazorIntAuto.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/BlazorIntAuto/BlazorIntAuto.csproj
+++ b/BlazorIntAuto/BlazorIntAuto.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.4.0" />
+    <PackageReference Include="Auth0.AspNetCore.Authentication" Version="1.4.1" />
     <ProjectReference Include="..\BlazorIntAuto.Client\BlazorIntAuto.Client.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Updated target framework for BlazorIntAuto.Client and BlazorIntAuto projects from .NET 8.0 to .NET 9.0.
- Upgraded `Microsoft.AspNetCore.Components.WebAssembly` and `Microsoft.AspNetCore.Components.WebAssembly.Authentication` packages to version 9.0.0 in BlazorIntAuto.Client.
- Updated `Auth0.AspNetCore.Authentication` package from version 1.4.0 to 1.4.1 in BlazorIntAuto.
- Upgraded `Microsoft.AspNetCore.Components.WebAssembly.Server` package to version 9.0.0 in BlazorIntAuto.